### PR TITLE
Implement First-Time User Need Help Dialog Box with sessionStorage Flag.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -102,10 +102,10 @@ export function closeNeedHelpDialog() {
 }
 
 // Open help modal on first visit
-document.addEventListener("DOMContentLoaded", function () {
-  if (!sessionStorage.getItem("hasSeenHelpModal")) {
+document.addEventListener('DOMContentLoaded', function () {
+  if (!sessionStorage.getItem('hasSeenHelpModal')) {
     showNeedHelpDialog();
-    sessionStorage.setItem("hasSeenHelpModal", "true");
+    sessionStorage.setItem('hasSeenHelpModal', 'true');
   }
 });
 

--- a/js/main.js
+++ b/js/main.js
@@ -101,6 +101,14 @@ export function closeNeedHelpDialog() {
   document.getElementById('need-help-modal').style.display = 'none';
 }
 
+// Open help modal on first visit
+document.addEventListener("DOMContentLoaded", function () {
+  if (!sessionStorage.getItem("hasSeenHelpModal")) {
+    showNeedHelpDialog();
+    sessionStorage.setItem("hasSeenHelpModal", "true");
+  }
+});
+
 // Close modal when clicking outside of it
 window.onclick = function (event) {
   const modal = document.getElementById('need-help-modal');


### PR DESCRIPTION
-On page load, the script checks if a sessionStorage flag is set (indicating that the user has already interacted with the modal).
-If the flag is not set, the modal will open, and once the user closes it, the flag will be saved in sessionStorage to prevent the modal from showing again on future visits.
closes #25 