### PR TITLE
Add Glow Effect to Start Button for Visual Emphasis

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -13,8 +13,16 @@
   border: none;
   padding: 18px 25px;
   font-size: 14px;
+  font-weight:700
   border-radius: 5px;
   cursor: pointer;
+  box-shadow: 0 0 8px #38a8db;
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.start-btn:hover {
+  box-shadow: 0 0 15px #38a8db, 0 0 25px #38a8db;
+  transform: scale(1.03);
 }
 
 .caption-description {

--- a/css/index.css
+++ b/css/index.css
@@ -13,7 +13,7 @@
   border: none;
   padding: 18px 25px;
   font-size: 14px;
-  font-weight:700
+  font-weight:700;
   border-radius: 5px;
   cursor: pointer;
   box-shadow: 0 0 8px #38a8db;

--- a/css/index.css
+++ b/css/index.css
@@ -13,15 +13,19 @@
   border: none;
   padding: 18px 25px;
   font-size: 14px;
-  font-weight:700;
+  font-weight: 700;
   border-radius: 5px;
   cursor: pointer;
   box-shadow: 0 0 8px #38a8db;
-  transition: box-shadow 0.3s ease, transform 0.3s ease;
+  transition:
+    box-shadow 0.3s ease,
+    transform 0.3s ease;
 }
 
 .start-btn:hover {
-  box-shadow: 0 0 15px #38a8db, 0 0 25px #38a8db;
+  box-shadow:
+    0 0 15px #38a8db,
+    0 0 25px #38a8db;
   transform: scale(1.03);
 }
 


### PR DESCRIPTION
This update introduces a subtle glow effect to the Start Button using a blue box-shadow. The purpose is to visually highlight the button on the focus page, drawing user attention without disrupting the overall design.

Changes include:

Added box-shadow for glow effect.

closes  #37 