### PR TITLE
Disable hover effect after subject selection

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -13,8 +13,16 @@
   border: none;
   padding: 18px 25px;
   font-size: 14px;
+  font-weight:700
   border-radius: 5px;
   cursor: pointer;
+  box-shadow: 0 0 8px #38a8db;
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.start-btn:hover {
+  box-shadow: 0 0 15px #38a8db, 0 0 25px #38a8db;
+  transform: scale(1.03);
 }
 
 .caption-description {

--- a/css/index.css
+++ b/css/index.css
@@ -13,7 +13,7 @@
   border: none;
   padding: 18px 25px;
   font-size: 14px;
-  font-weight:700
+  font-weight:700;
   border-radius: 5px;
   cursor: pointer;
   box-shadow: 0 0 8px #38a8db;

--- a/css/index.css
+++ b/css/index.css
@@ -13,15 +13,19 @@
   border: none;
   padding: 18px 25px;
   font-size: 14px;
-  font-weight:700;
+  font-weight: 700;
   border-radius: 5px;
   cursor: pointer;
   box-shadow: 0 0 8px #38a8db;
-  transition: box-shadow 0.3s ease, transform 0.3s ease;
+  transition:
+    box-shadow 0.3s ease,
+    transform 0.3s ease;
 }
 
 .start-btn:hover {
-  box-shadow: 0 0 15px #38a8db, 0 0 25px #38a8db;
+  box-shadow:
+    0 0 15px #38a8db,
+    0 0 25px #38a8db;
   transform: scale(1.03);
 }
 

--- a/js/qna.js
+++ b/js/qna.js
@@ -62,6 +62,10 @@ export function selectQuestionsSubject(node) {
     document.querySelector('#secondOption').style.cursor = 'default';
     document.querySelector('.result-button').style.display = 'flex';
 
+    // Disable hover effect
+    document.querySelector('#firstOption').style.pointerEvents = 'none';
+    document.querySelector('#secondOption').style.pointerEvents = 'none';
+
     // save the result data in the session storage
     setSubjectResult(subjectVsQuestionCountForResult);
     return;


### PR DESCRIPTION
This PR addresses the issue where the hover effect on subject buttons remained active even after both subjects were selected. It disables the hover effect after selection is complete.

closes https://github.com/SagarGi/focusflow/issues/35