### PR TITLE
Position the close button inside the modal box

### DIFF
--- a/css/focus-flow-main.css
+++ b/css/focus-flow-main.css
@@ -181,6 +181,7 @@ header {
   border-radius: 8px;
   width: 35%;
   text-align: center;
+  position: relative;
 }
 
 .modal-container {

--- a/css/index.css
+++ b/css/index.css
@@ -13,8 +13,16 @@
   border: none;
   padding: 18px 25px;
   font-size: 14px;
+  font-weight:700
   border-radius: 5px;
   cursor: pointer;
+  box-shadow: 0 0 8px #38a8db;
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.start-btn:hover {
+  box-shadow: 0 0 15px #38a8db, 0 0 25px #38a8db;
+  transform: scale(1.03);
 }
 
 .caption-description {

--- a/css/index.css
+++ b/css/index.css
@@ -13,7 +13,7 @@
   border: none;
   padding: 18px 25px;
   font-size: 14px;
-  font-weight:700
+  font-weight:700;
   border-radius: 5px;
   cursor: pointer;
   box-shadow: 0 0 8px #38a8db;

--- a/css/index.css
+++ b/css/index.css
@@ -13,15 +13,19 @@
   border: none;
   padding: 18px 25px;
   font-size: 14px;
-  font-weight:700;
+  font-weight: 700;
   border-radius: 5px;
   cursor: pointer;
   box-shadow: 0 0 8px #38a8db;
-  transition: box-shadow 0.3s ease, transform 0.3s ease;
+  transition:
+    box-shadow 0.3s ease,
+    transform 0.3s ease;
 }
 
 .start-btn:hover {
-  box-shadow: 0 0 15px #38a8db, 0 0 25px #38a8db;
+  box-shadow:
+    0 0 15px #38a8db,
+    0 0 25px #38a8db;
   transform: scale(1.03);
 }
 

--- a/js/qna.js
+++ b/js/qna.js
@@ -62,6 +62,10 @@ export function selectQuestionsSubject(node) {
     document.querySelector('#secondOption').style.cursor = 'default';
     document.querySelector('.result-button').style.display = 'flex';
 
+    // Disable hover effect
+    document.querySelector('#firstOption').style.pointerEvents = 'none';
+    document.querySelector('#secondOption').style.pointerEvents = 'none';
+
     // save the result data in the session storage
     setSubjectResult(subjectVsQuestionCountForResult);
     return;


### PR DESCRIPTION
### Problem:
The close button (`&times;`) was located outside the modal box, which caused layout issues.

### Solution:
This PR updates the CSS for the modal close button (`&times;`) to ensure it is positioned correctly inside the modal box, relative to the modal. 

### Testing:
- The close button (`&times;`)  is now positioned inside the modal box and can be clicked.

closes #43 